### PR TITLE
Fix broken empty comment header.

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -168,7 +168,7 @@ pub fn encode<const S_PS: u32, const NUM_CHANNELS: u8>(audio: &[i16]) -> Result<
     LittleEndian::write_u32(&mut len_bf, vendor_str.len() as u32);
     opus_tags.extend(&len_bf);
     opus_tags.extend(vendor_str.bytes());
-    opus_tags.extend(&[0]); // No user comments
+    opus_tags.extend(&[0u8;4]); // No user comments
 
     packet_writer.write_packet(Box::new(head), serial, ogg::PacketWriteEndInfo::EndPage, 0)?;
     packet_writer.write_packet(opus_tags.into_boxed_slice(), serial, ogg::PacketWriteEndInfo::EndPage, 0)?;


### PR DESCRIPTION
According to RFC 7845 5.2, 'User Comment List Length' should be 32bits LE.

This fixes the following opusinfo message on broken file:

  WARNING: Could not decode OpusTags header packet 1 - invalid Opus stream (1)
  Opus stream 1:
	WARNING: stream 1 is empty
  Logical stream 1 ended

There are still other issues to be resolved, but at least opus tags can be written now.