### PR TITLE
Refactoring, improve decode performance, less allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["test_assets/*"] # Don't upload files for testing
 ogg = "^0.9.1"
 audiopus = "^0.3.0-rc.0"
 byteorder = "^1.3"
-thiserror = "^1.0"
+thiserror = "^2.0"
 rand = "^0.8"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogg-opus"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["sheosi <sertorbe@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ exclude = ["test_assets/*"] # Don't upload files for testing
 
 
 [dependencies]
-ogg = "^0.8"
-audiopus = "^0.2" 
+ogg = "^0.9.1"
+audiopus = "^0.3.0-rc.0"
 byteorder = "^1.3"
 thiserror = "^1.0"
 rand = "^0.8"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ogg-opus = "^0.1"
 
 ## Minimum Rust version
 
-Since we use `const generics`, the minimum version of [Rust](https://www.rust-lang.org/) is [1.51](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html)
+Since we use `inline const expressions`, the minimum version of [Rust](https://www.rust-lang.org/) is [1.79](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html)
 
 # Example
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,21 +5,28 @@ use audiopus::SampleRate;
 // We use this to check whether a file is ogg opus or not inside the client
 pub(crate) const OGG_OPUS_SPS: u32 = 48000;
 pub(crate) const MAX_NUM_CHANNELS: u8 = 2;
+pub(crate) const OPUS_MAGIC_HEADER: [u8; 8] = [b'O', b'p', b'u', b's', b'H', b'e', b'a', b'd'];
+pub(crate) const MAX_FRAME_SAMPLES: usize = 5760; // According to opus_decode docs
+pub(crate) const MAX_FRAME_SIZE: usize = MAX_FRAME_SAMPLES * (MAX_NUM_CHANNELS as usize); // Our buffer will be i16 so, don't convert to bytes
+pub(crate) const FRAME_TIME_MS: u32 = 20;
+pub(crate) const MAX_PACKET: usize = 4000; // Maximum theorical recommended by Opus
+pub(crate) const MIN_FRAME_MICROS: u32 = 25;
+pub(crate) const VENDOR_STR: &str = concat!("ogg-opus", " ", std::env!("CARGO_PKG_VERSION"));
 
-pub(crate) const fn calc_sr(val:u16, org_sr: u32, dest_sr: u32) -> u16 {
-    ((val as u32 * dest_sr) /org_sr) as u16
+pub(crate) const fn calc_sr(val: u16, org_sr: u32, dest_sr: u32) -> u16 {
+    ((val as u32 * dest_sr) / org_sr) as u16
 }
-pub(crate) const fn calc_sr_u64(val:u64, org_sr: u32, dest_sr: u32) -> u64 {
-    (val * dest_sr as u64) /(org_sr as u64)
+pub(crate) const fn calc_sr_u64(val: u64, org_sr: u32, dest_sr: u32) -> u64 {
+    (val * dest_sr as u64) / (org_sr as u64)
 }
 
-pub(crate) const fn s_ps_to_audiopus(s_ps: u32) -> Result<SampleRate, Error> { 
+pub(crate) const fn s_ps_to_audiopus(s_ps: u32) -> Result<SampleRate, Error> {
     match s_ps {
         8000 => Ok(SampleRate::Hz8000),
         12000 => Ok(SampleRate::Hz12000),
         16000 => Ok(SampleRate::Hz16000),
         24000 => Ok(SampleRate::Hz24000),
         48000 => Ok(SampleRate::Hz48000),
-        _ => return Err(Error::InvalidSps)
+        _ => Err(Error::InvalidSps),
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,3 @@
-use crate::Error;
-
 use audiopus::SampleRate;
 
 // We use this to check whether a file is ogg opus or not inside the client
@@ -12,6 +10,41 @@ pub(crate) const FRAME_TIME_MS: u32 = 20;
 pub(crate) const MAX_PACKET: usize = 4000; // Maximum theorical recommended by Opus
 pub(crate) const MIN_FRAME_MICROS: u32 = 25;
 pub(crate) const VENDOR_STR: &str = concat!("ogg-opus", " ", std::env!("CARGO_PKG_VERSION"));
+pub(crate) const VENDOR_STR_LEN: [u8; 4] = (VENDOR_STR.len() as u32).to_le_bytes();
+pub(crate) const VENDOR_STR_BYTES: &[u8] = VENDOR_STR.as_bytes();
+
+pub(crate) const OPUS_TAGS: [u8; 30] = [
+    b'O',
+    b'p',
+    b'u',
+    b's',
+    b'T',
+    b'a',
+    b'g',
+    b's',
+    VENDOR_STR_LEN[0],
+    VENDOR_STR_LEN[1],
+    VENDOR_STR_LEN[2],
+    VENDOR_STR_LEN[3],
+    VENDOR_STR_BYTES[0],
+    VENDOR_STR_BYTES[1],
+    VENDOR_STR_BYTES[2],
+    VENDOR_STR_BYTES[3],
+    VENDOR_STR_BYTES[4],
+    VENDOR_STR_BYTES[5],
+    VENDOR_STR_BYTES[6],
+    VENDOR_STR_BYTES[7],
+    VENDOR_STR_BYTES[8],
+    VENDOR_STR_BYTES[9],
+    VENDOR_STR_BYTES[10],
+    VENDOR_STR_BYTES[11],
+    VENDOR_STR_BYTES[12],
+    VENDOR_STR_BYTES[13],
+    0,
+    0,
+    0,
+    0,
+];
 
 pub(crate) const fn calc_sr(val: u16, org_sr: u32, dest_sr: u32) -> u16 {
     ((val as u32 * dest_sr) / org_sr) as u16
@@ -20,13 +53,13 @@ pub(crate) const fn calc_sr_u64(val: u64, org_sr: u32, dest_sr: u32) -> u64 {
     (val * dest_sr as u64) / (org_sr as u64)
 }
 
-pub(crate) const fn s_ps_to_audiopus(s_ps: u32) -> Result<SampleRate, Error> {
-    match s_ps {
-        8000 => Ok(SampleRate::Hz8000),
-        12000 => Ok(SampleRate::Hz12000),
-        16000 => Ok(SampleRate::Hz16000),
-        24000 => Ok(SampleRate::Hz24000),
-        48000 => Ok(SampleRate::Hz48000),
-        _ => Err(Error::InvalidSps),
-    }
+pub(crate) const fn s_ps_to_audiopus(s_ps: u32) -> Option<SampleRate> {
+    Some(match s_ps {
+        8000 => SampleRate::Hz8000,
+        12000 => SampleRate::Hz12000,
+        16000 => SampleRate::Hz16000,
+        24000 => SampleRate::Hz24000,
+        48000 => SampleRate::Hz48000,
+        _ => return None,
+    })
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,10 +1,10 @@
-use std::io::{Read, Seek};
-
-use crate::Error;
 use crate::common::*;
-use byteorder::{LittleEndian, ByteOrder};
+use crate::Error;
+use audiopus::coder::{Decoder as OpusDec, GenericCtl};
+use byteorder::{ByteOrder, LittleEndian};
 use ogg::{Packet, PacketReader};
-use audiopus::{coder::{Decoder as OpusDec, GenericCtl}};
+use std::convert::TryFrom;
+use std::io::{Read, Seek};
 
 //--- Final range  things ------------------------------------------------------
 
@@ -17,131 +17,142 @@ thread_local! {
 }
 
 #[cfg(test)]
-fn set_final_range(r:u32) {
-    LAST_FINAL_RANGE.with(|f|*f.borrow_mut() = r);
+fn set_final_range(r: u32) {
+    LAST_FINAL_RANGE.with(|f| *f.borrow_mut() = r);
 }
 
 // Just here so that it can be used in the function
 #[cfg(not(test))]
-fn set_final_range(_:u32) {}
+fn set_final_range(_: u32) {}
 
 #[cfg(test)]
 pub(crate) fn get_final_range() -> u32 {
-    LAST_FINAL_RANGE.with(|f|*f.borrow())
+    LAST_FINAL_RANGE.with(|f| *f.borrow())
 }
 
 //--- Code ---------------------------------------------------------------------
 
 pub struct PlayData {
-    pub channels: u16
+    pub channels: u16,
 }
 
-pub(crate) const OPUS_MAGIC_HEADER:[u8;8] = [b'O', b'p', b'u', b's', b'H', b'e', b'a', b'd'];
+struct DecodeData {
+    pre_skip: u16,
+    gain: i32,
+}
 
-/**Reads audio from Ogg Opus, note: it only can read from the ones produced 
+/**Reads audio from Ogg Opus, note: it only can read from the ones produced
 by itself, this is not ready for anything more, third return is final range just
 available while testing, otherwise it is a 0*/
-pub fn decode<T: Read + Seek, const TARGET_SPS: u32>(data: T) -> Result<(Vec<i16>, PlayData), Error> {
+pub fn decode<T: Read + Seek, const TARGET_SPS: u32>(
+    data: T,
+) -> Result<(Vec<i16>, PlayData), Error> {
     // Data
-    const MAX_FRAME_SAMPLES: usize = 5760; // According to opus_decode docs
-    const MAX_FRAME_SIZE: usize = MAX_FRAME_SAMPLES * (MAX_NUM_CHANNELS as usize); // Our buffer will be i16 so, don't convert to bytes
 
     let mut reader = PacketReader::new(data);
-    let fp = reader.read_packet_expected().map_err(|_| Error::MalformedAudio)?; // Header
 
-    struct DecodeData {
-        pre_skip: u16,
-        gain: i32
-    }
-
-    // Analyze first page, where all the metadata we need is contained
-    fn check_fp<const TARGET_SPS: u32>(fp: &Packet) -> Result<(PlayData, DecodeData), Error> {
-
-        // Check size
-        if fp.data.len() < 19 {
-            return Err(Error::MalformedAudio)
-        }
-
-        // Read magic header
-        if fp.data[0..8] != OPUS_MAGIC_HEADER {
-            return Err(Error::MalformedAudio)
-        }
-
-        // Read version
-        if fp.data[8] != 1 {
-            return Err(Error::MalformedAudio)
-        }
-        
-
-        Ok((
-            PlayData{
-                channels: fp.data[9] as u16, // Number of channels
-            },
-            DecodeData {
-                pre_skip: calc_sr(LittleEndian::read_u16(&fp.data[10..12]), OGG_OPUS_SPS, TARGET_SPS),
-                gain: LittleEndian::read_i16(&fp.data[16..18]) as i32
-            }
-        ))
-    }
+    let fp = reader
+        .read_packet_expected()
+        .map_err(|_| Error::MalformedAudio)?;
 
     let (play_data, dec_data) = check_fp::<TARGET_SPS>(&fp)?;
 
     let chans = match play_data.channels {
         1 => Ok(audiopus::Channels::Mono),
         2 => Ok(audiopus::Channels::Stereo),
-        _ => Err(Error::MalformedAudio)
+        _ => Err(Error::MalformedAudio),
     }?;
 
     let opus_sr = s_ps_to_audiopus(TARGET_SPS)?;
 
     // According to RFC7845 if a device supports 48Khz, decode at this rate
-    let mut decoder =  OpusDec::new(opus_sr, chans)?;
+    let mut decoder = OpusDec::new(opus_sr, chans)?;
     decoder.set_gain(dec_data.gain)?;
 
     // Vendor and other tags, do a basic check
-    let sp = reader.read_packet_expected().map_err(|_| Error::MalformedAudio)?; // Tags
-    fn check_sp(sp: &Packet) -> Result<(), Error> {
-        if sp.data.len() < 12 {
-            return Err(Error::MalformedAudio)
-        }
+    let sp = reader
+        .read_packet_expected()
+        .map_err(|_| Error::MalformedAudio)?;
 
-        let head = std::str::from_utf8(&sp.data[0..8]).or_else(|_| Err(Error::MalformedAudio))?;
-        if head != "OpusTags" {
-            return Err(Error::MalformedAudio)
-        }
-        
-        Ok(())
-    }
-        
     check_sp(&sp)?;
 
     let mut buffer: Vec<i16> = Vec::new();
     let mut rem_skip = dec_data.pre_skip as usize;
     let mut dec_absgsp = 0;
+
     while let Some(packet) = reader.read_packet()? {
         let mut temp_buffer = [0i16; MAX_FRAME_SIZE];
-        let out_size = decoder.decode(Some(&packet.data), &mut temp_buffer[..], false)?;
-        let absgsp = calc_sr_u64(packet.absgp_page(),OGG_OPUS_SPS, TARGET_SPS) as usize;
+        let inner_packet = audiopus::packet::Packet::try_from(&packet.data)?;
+        let again_buffer = audiopus::MutSignals::try_from(&mut temp_buffer[..])?;
+
+        let out_size = decoder.decode(Some(inner_packet), again_buffer, false)?;
+        let absgsp = calc_sr_u64(packet.absgp_page(), OGG_OPUS_SPS, TARGET_SPS) as usize;
+
         dec_absgsp += out_size;
+
         let trimmed_end = if packet.last_in_stream() && dec_absgsp > absgsp {
-            (out_size as usize * play_data.channels as usize) - (dec_absgsp - absgsp)
-        }
-        else {
+            (out_size * play_data.channels as usize) - (dec_absgsp - absgsp)
+        } else {
             // out_size == num of samples *per channel*
-            out_size as usize * play_data.channels as usize
-        } as usize;
+            out_size * play_data.channels as usize
+        };
 
         if rem_skip < out_size {
             buffer.extend_from_slice(&temp_buffer[rem_skip..trimmed_end]);
             rem_skip = 0;
-        }
-        else {
+        } else {
             rem_skip -= out_size;
         }
-
     }
 
-    if cfg!(test) {set_final_range(decoder.final_range().unwrap())};
+    if cfg!(test) {
+        set_final_range(decoder.final_range().unwrap())
+    };
 
-    Ok( (buffer, play_data))
+    Ok((buffer, play_data))
+}
+
+fn check_sp(sp: &Packet) -> Result<(), Error> {
+    if sp.data.len() < 12 {
+        return Err(Error::MalformedAudio);
+    }
+
+    let head = std::str::from_utf8(&sp.data[0..8]).map_err(|_| Error::MalformedAudio)?;
+    if head != "OpusTags" {
+        return Err(Error::MalformedAudio);
+    }
+
+    Ok(())
+}
+
+// Analyze first page, where all the metadata we need is contained
+fn check_fp<const TARGET_SPS: u32>(fp: &Packet) -> Result<(PlayData, DecodeData), Error> {
+    // Check size
+    if fp.data.len() < 19 {
+        return Err(Error::MalformedAudio);
+    }
+
+    // Read magic header
+    if fp.data[0..8] != OPUS_MAGIC_HEADER {
+        return Err(Error::MalformedAudio);
+    }
+
+    // Read version
+    if fp.data[8] != 1 {
+        return Err(Error::MalformedAudio);
+    }
+
+    Ok((
+        PlayData {
+            channels: fp.data[9] as u16, // Number of channels
+        },
+        DecodeData {
+            pre_skip: calc_sr(
+                LittleEndian::read_u16(&fp.data[10..12]),
+                OGG_OPUS_SPS,
+                TARGET_SPS,
+            ),
+            gain: LittleEndian::read_i16(&fp.data[16..18]) as i32,
+        },
+    ))
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,12 +1,16 @@
+use std::borrow::Cow;
 use std::cmp::min;
 use std::process;
 
-use crate::Error;
 use crate::common::*;
+use crate::Error;
 
-use byteorder::{LittleEndian, ByteOrder};
+use audiopus::{
+    coder::{Encoder as OpusEnc, GenericCtl},
+    Bitrate,
+};
+use byteorder::{ByteOrder, LittleEndian};
 use ogg::PacketWriter;
-use audiopus::{Bitrate, coder::{Encoder as OpusEnc, GenericCtl}};
 use rand::Rng;
 
 //--- Final range  things ------------------------------------------------------
@@ -20,189 +24,160 @@ thread_local! {
 }
 
 #[cfg(test)]
-fn set_final_range(r:u32) {
-    LAST_FINAL_RANGE.with(|f|*f.borrow_mut() = r);
+fn set_final_range(r: u32) {
+    LAST_FINAL_RANGE.with(|f| *f.borrow_mut() = r);
 }
 
 // Just here so that it can be used in the function
 #[cfg(not(test))]
-fn set_final_range(_:u32) {}
+fn set_final_range(_: u32) {}
 
 #[cfg(test)]
 pub(crate) fn get_final_range() -> u32 {
-    LAST_FINAL_RANGE.with(|f|*f.borrow())
+    LAST_FINAL_RANGE.with(|f| *f.borrow())
 }
 
 //--- Code ---------------------------------------------------------------------
-
-const VER: &str = std::env!("CARGO_PKG_VERSION");
-
 const fn to_samples<const S_PS: u32>(ms: u32) -> usize {
     ((S_PS * ms) / 1000) as usize
 }
 
-
 // In microseconds
-const fn calc_fr_size(us: u32, channels:u8, sps:u32) -> usize {
-    let samps_ms = (sps * us) as u32;
+const fn calc_fr_size(us: u32, channels: u8, sps: u32) -> usize {
+    let samps_ms = sps * us;
     const US_TO_MS: u32 = 10;
-    ((samps_ms * channels as u32 ) / (1000 * US_TO_MS )) as usize
+    ((samps_ms * channels as u32) / (1000 * US_TO_MS)) as usize
 }
 
-
-const fn opus_channels(val: u8) -> audiopus::Channels{
-    if val == 0 {
-        // Never should be 0
+const fn opus_channels(val: u8) -> audiopus::Channels {
+    if val == 1 || val == 0 {
         audiopus::Channels::Mono
+    } else {
+        audiopus::Channels::Stereo
     }
-    else if val == 1 {
-       audiopus::Channels::Mono
+}
+
+// Calc the biggest frame buffer that still is either smaller or the
+// same size as the input
+fn calc_biggest_spills<T: PartialOrd + Copy>(val: T, possibles: &[T]) -> Option<T> {
+    for container in possibles.iter().rev() {
+        if *container <= val {
+            return Some(*container);
+        }
     }
-    else {
-       audiopus::Channels::Stereo
+    None
+}
+
+const fn is_end_of_stream(pos: usize, max: usize) -> ogg::PacketWriteEndInfo {
+    if pos == max {
+        ogg::PacketWriteEndInfo::EndStream
+    } else {
+        ogg::PacketWriteEndInfo::NormalPacket
     }
+}
+
+const fn granule<const S_PS: u32>(val: usize) -> u64 {
+    calc_sr_u64(val as u64, S_PS, OGG_OPUS_SPS)
 }
 
 pub fn encode<const S_PS: u32, const NUM_CHANNELS: u8>(audio: &[i16]) -> Result<Vec<u8>, Error> {
-    //NOTE: In the future the S_PS const generic will let us use const on a lot 
+    //NOTE: In the future the S_PS const generic will let us use const on a lot
     // of things, until then we need to use variables
 
     // This should have a bitrate of 24 Kb/s, exactly what IBM recommends
 
     // More frame time, sligtly less overhead more problematic packet loses,
     // a frame time of 20ms is considered good enough for most applications
-    
-    // Data
-    const FRAME_TIME_MS: u32 = 20;
-    const MAX_PACKET: usize = 4000; // Maximum theorical recommended by Opus
-    const MIN_FRAME_MICROS: u32 = 25;
 
+    // Data
     let frame_samples: usize = to_samples::<S_PS>(FRAME_TIME_MS);
     let frame_size: usize = frame_samples * (NUM_CHANNELS as usize);
 
     // Generate the serial which is nothing but a value to identify a stream, we
-    // will also use the process id so that two programs don't use 
+    // will also use the process id so that two programs don't use
     // the same serial even if getting one at the same time
     let mut rnd = rand::thread_rng();
     let serial = rnd.gen::<u32>() ^ process::id();
-    let mut buffer: Vec<u8> = Vec::new();
-    
-    let mut packet_writer = PacketWriter::new(&mut buffer);
 
     let opus_sr = s_ps_to_audiopus(S_PS)?;
 
-    let mut opus_encoder = OpusEnc::new(opus_sr, opus_channels(NUM_CHANNELS), audiopus::Application::Audio)?;
+    let mut opus_encoder = OpusEnc::new(
+        opus_sr,
+        opus_channels(NUM_CHANNELS),
+        audiopus::Application::Audio,
+    )?;
+    // Balance with quality, speed and size, especially for Telegram
     opus_encoder.set_bitrate(Bitrate::BitsPerSecond(24000))?;
 
-    let skip = opus_encoder.lookahead().unwrap() as u16;
+    let skip = opus_encoder.lookahead()? as u16;
+    let inner_encoder = InnerEncoder {
+        encoder: opus_encoder,
+    };
     let skip_us = skip as usize;
     let tot_samples = audio.len() + skip_us;
-    let skip_48 = calc_sr(
-        skip,
-        S_PS,
-        OGG_OPUS_SPS
-    );
+    let skip_48 = calc_sr(skip, S_PS, OGG_OPUS_SPS);
 
-    let max = (tot_samples as f32 / frame_size as f32).floor() as u32;
+    let max = (tot_samples as f32 / frame_size as f32).floor() as usize;
 
-    let calc = |counter: u32| -> usize {
-        (counter as usize) * frame_size
-    };
-
-    let calc_samples = |counter:u32| -> usize {
-        (counter as usize) * frame_samples
-    };
-
-    const fn granule<const S_PS: u32>(val: usize) -> u64 {
-        calc_sr_u64(val as u64, S_PS, OGG_OPUS_SPS)
-    }
+    let calc = |counter| -> usize { counter * frame_size };
+    let calc_samples = |counter| -> usize { counter * frame_samples };
+    let mut buffer: Vec<u8> = Vec::with_capacity(calc(max));
+    let mut packet_writer = PacketWriter::new(&mut buffer);
 
     let opus_head: [u8; 19] = [
-        b'O', b'p', b'u', b's', b'H', b'e', b'a', b'd', // Magic header
-        1, // Version number, always 1
+        OPUS_MAGIC_HEADER[0],
+        OPUS_MAGIC_HEADER[1],
+        OPUS_MAGIC_HEADER[2],
+        OPUS_MAGIC_HEADER[3],
+        OPUS_MAGIC_HEADER[4],
+        OPUS_MAGIC_HEADER[5],
+        OPUS_MAGIC_HEADER[6],
+        OPUS_MAGIC_HEADER[7],
+        // Magic header
+        1,            // Version number, always 1
         NUM_CHANNELS, // Channels
-        0, 0,//Pre-skip
-        0, 0, 0, 0, // Original Hz (informational)
-        0, 0, // Output gain
+        0,
+        0, //Pre-skip
+        0,
+        0,
+        0,
+        0, // Original Hz (informational)
+        0,
+        0, // Output gain
         0, // Channel map family
-        // If Channel map != 0, here should go channel mapping table
+           // If Channel map != 0, here should go channel mapping table
     ];
-
-    fn encode_vec(opus_encoder: &mut OpusEnc, audio: &[i16]) -> Result<Box<[u8]>, Error> {
-        let mut output: Vec<u8> = vec![0; MAX_PACKET];
-		let result = opus_encoder.encode(audio, output.as_mut_slice())?;
-		output.truncate(result);
-		Ok(output.into_boxed_slice())
-    }
-
-    fn encode_with_skip(opus_encoder: &mut OpusEnc, audio: &[i16], pos_a: usize, pos_b: usize, skip_us: usize) -> Result<Box<[u8]>, Error> {
-        if pos_a > skip_us {
-            encode_vec(opus_encoder, &audio[pos_a-skip_us..pos_b-skip_us])
-        }
-        else {
-            let mut buf = vec![0; pos_b-pos_a];
-            if pos_b > skip_us {
-                buf[skip_us - pos_a..].copy_from_slice(&audio[.. pos_b - skip_us]);
-            }
-            encode_vec(opus_encoder, &buf)
-        }
-    }
-
-    fn is_end_of_stream(pos: usize, max: usize) -> ogg::PacketWriteEndInfo {
-        if pos == max {
-            ogg::PacketWriteEndInfo::EndStream
-        }
-        else {
-            ogg::PacketWriteEndInfo::NormalPacket
-        }
-    }
 
     let mut head = opus_head;
     LittleEndian::write_u16(&mut head[10..12], skip_48 as u16); // Write pre-skip
     LittleEndian::write_u32(&mut head[12..16], S_PS); // Write Samples per second
 
-    let mut opus_tags : Vec<u8> = Vec::with_capacity(60);
-    let vendor_str = format!("ogg-opus {}", VER);
+    let mut opus_tags: Vec<u8> = Vec::with_capacity(60);
     opus_tags.extend(b"OpusTags");
-    let mut len_bf = [0u8;4];
-    LittleEndian::write_u32(&mut len_bf, vendor_str.len() as u32);
+    let mut len_bf = [0u8; 4];
+    LittleEndian::write_u32(&mut len_bf, VENDOR_STR.len() as u32);
     opus_tags.extend(&len_bf);
-    opus_tags.extend(vendor_str.bytes());
-    opus_tags.extend(&[0u8;4]); // No user comments
+    opus_tags.extend(VENDOR_STR.bytes());
+    opus_tags.extend(&[0u8; 4]); // No user comments
 
-    packet_writer.write_packet(Box::new(head), serial, ogg::PacketWriteEndInfo::EndPage, 0)?;
-    packet_writer.write_packet(opus_tags.into_boxed_slice(), serial, ogg::PacketWriteEndInfo::EndPage, 0)?;
+    packet_writer.write_packet(&head[..], serial, ogg::PacketWriteEndInfo::EndPage, 0)?;
+    packet_writer.write_packet(opus_tags, serial, ogg::PacketWriteEndInfo::EndPage, 0)?;
 
     // Do all frames
-    for counter in 0..max{ // Last value of counter is max - 1 
-        let pos_a: usize = calc(counter);
-        let pos_b: usize = calc(counter + 1);
-        
+    for counter in 0..max {
+        // Last value of counter is max - 1
+        let pos_a = calc(counter);
+        let pos_b = calc(counter + 1);
         assert!((pos_b - pos_a) <= frame_size);
-        
-        let new_buffer = encode_with_skip(&mut opus_encoder, audio, pos_a, pos_b, skip_us)?;
+
+        let new_buffer = inner_encoder.encode_with_skip(audio, pos_a, pos_b, skip_us)?;
 
         packet_writer.write_packet(
             new_buffer,
             serial,
             is_end_of_stream(pos_b, tot_samples),
-            granule::<S_PS>(skip_us + calc_samples(counter + 1)
-        ))?;
-    }
-
-    // Calc the biggest frame buffer that still is either smaller or the
-    // same size as the input
-    fn calc_biggest_spills<T:PartialOrd + Copy>(val: T, possibles: &[T]) -> Option<T> {
-        for container in possibles.iter().rev()  {
-            if *container <= val {
-                return Some(*container)
-            }
-        }
-        None
-    }
-
-    fn encode_no_skip(opus_encoder: &mut OpusEnc, audio: &[i16], start: usize, frame_size : usize) -> Result<Box<[u8]>, Error> {
-        encode_vec(opus_encoder, &audio[start .. start + frame_size])
+            granule::<S_PS>(skip_us + calc_samples(counter + 1)),
+        )?;
     }
 
     // Try to add as less of empty audio as possible, first everything into
@@ -211,55 +186,100 @@ pub fn encode<const S_PS: u32, const NUM_CHANNELS: u8>(audio: &[i16]) -> Result<
     let mut last_sample = calc(max);
     assert!(last_sample <= audio.len() + skip_us);
     let frame_sizes: [usize; 4] = [
-            calc_fr_size(MIN_FRAME_MICROS, NUM_CHANNELS, S_PS),
-            calc_fr_size(50, NUM_CHANNELS, S_PS),
-            calc_fr_size(100, NUM_CHANNELS, S_PS),
-            calc_fr_size(200, NUM_CHANNELS, S_PS)
+        calc_fr_size(MIN_FRAME_MICROS, NUM_CHANNELS, S_PS),
+        calc_fr_size(50, NUM_CHANNELS, S_PS),
+        calc_fr_size(100, NUM_CHANNELS, S_PS),
+        calc_fr_size(200, NUM_CHANNELS, S_PS),
     ];
 
     while last_sample < tot_samples {
+        let rem_samples = tot_samples - last_sample;
+        let last_audio_s = last_sample - min(last_sample, skip_us);
 
-            let rem_samples = tot_samples - last_sample;
-            let last_audio_s = last_sample - min(last_sample,skip_us);
-
-            match calc_biggest_spills(rem_samples, &frame_sizes) {
-                Some(frame_size) => {
-                    let enc = if last_sample >= skip_us {
-                        encode_no_skip(&mut opus_encoder, audio, last_audio_s, frame_size)?
-                    }
-                    else {
-                        encode_with_skip(&mut opus_encoder, audio, last_sample, last_sample + frame_size, skip_us)?
-                    };
-                    last_sample += frame_size;
-                    packet_writer.write_packet(
-                        enc,
-                        serial, 
-                        is_end_of_stream(last_sample, tot_samples),
-                        granule::<S_PS>(last_sample/(NUM_CHANNELS as usize))
-                    )?;
-                }
-                None => {
-                    // Maximum size for a 2.5 ms frame
-                    const MAX_25_SIZE: usize = calc_fr_size(MIN_FRAME_MICROS, MAX_NUM_CHANNELS, OGG_OPUS_SPS);
-                    let mut in_buffer = [0i16;MAX_25_SIZE];
-                    let rem_skip = skip_us - min(last_sample, skip_us);
-                    in_buffer[rem_skip..rem_samples].copy_from_slice(&audio[last_audio_s..]);
-
-                    last_sample = tot_samples; // We end this here
-                    
-                    packet_writer.write_packet(
-                        encode_no_skip(&mut opus_encoder, &in_buffer, 0, frame_sizes[0])?,
-                        serial, 
-                        ogg::PacketWriteEndInfo::EndStream,
-                        granule::<S_PS>((skip_us + audio.len())/(NUM_CHANNELS as usize))
-                    )?;
-                    
-                }
+        match calc_biggest_spills(rem_samples, &frame_sizes) {
+            Some(frame_size) => {
+                let enc = if last_sample >= skip_us {
+                    inner_encoder.encode_no_skip(audio, last_audio_s, frame_size)?
+                } else {
+                    inner_encoder.encode_with_skip(
+                        audio,
+                        last_sample,
+                        last_sample + frame_size,
+                        skip_us,
+                    )?
+                };
+                last_sample += frame_size;
+                packet_writer.write_packet(
+                    enc,
+                    serial,
+                    is_end_of_stream(last_sample, tot_samples),
+                    granule::<S_PS>(last_sample / (NUM_CHANNELS as usize)),
+                )?;
             }
-            
-        }
+            None => {
+                // Maximum size for a 2.5 ms frame
+                const MAX_25_SIZE: usize =
+                    calc_fr_size(MIN_FRAME_MICROS, MAX_NUM_CHANNELS, OGG_OPUS_SPS);
+                let mut in_buffer = [0i16; MAX_25_SIZE];
+                let rem_skip = skip_us - min(last_sample, skip_us);
+                in_buffer[rem_skip..rem_samples].copy_from_slice(&audio[last_audio_s..]);
 
-    if cfg!(test) {set_final_range(opus_encoder.final_range().unwrap())}
+                last_sample = tot_samples; // We end this here
+
+                let enc = inner_encoder.encode_no_skip(&in_buffer, 0, frame_sizes[0])?;
+                packet_writer.write_packet(
+                    enc,
+                    serial,
+                    ogg::PacketWriteEndInfo::EndStream,
+                    granule::<S_PS>((skip_us + audio.len()) / (NUM_CHANNELS as usize)),
+                )?;
+            }
+        }
+    }
+
+    if cfg!(test) {
+        set_final_range(inner_encoder.encoder.final_range().unwrap())
+    }
 
     Ok(buffer)
+}
+
+struct InnerEncoder {
+    encoder: OpusEnc,
+}
+
+impl InnerEncoder {
+    fn encode_vec(&self, audio: &[i16]) -> Result<Cow<'_, [u8]>, Error> {
+        let mut output: Vec<u8> = vec![0; MAX_PACKET];
+        let result = self.encoder.encode(audio, &mut output)?;
+        output.truncate(result);
+        Ok(output.into())
+    }
+
+    fn encode_with_skip(
+        &self,
+        audio: &[i16],
+        pos_a: usize,
+        pos_b: usize,
+        skip_us: usize,
+    ) -> Result<Cow<'_, [u8]>, Error> {
+        if pos_a > skip_us {
+            self.encode_vec(&audio[pos_a - skip_us..pos_b - skip_us])
+        } else {
+            let mut buf = vec![0; pos_b - pos_a];
+            if pos_b > skip_us {
+                buf[skip_us - pos_a..].copy_from_slice(&audio[..pos_b - skip_us]);
+            }
+            self.encode_vec(&buf)
+        }
+    }
+
+    fn encode_no_skip(
+        &self,
+        audio: &[i16],
+        start: usize,
+        frame_size: usize,
+    ) -> Result<Cow<'_, [u8]>, Error> {
+        self.encode_vec(&audio[start..start + frame_size])
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,9 @@ mod tests {
 
     fn read_file_i16(path: &str) -> Vec<i16> {
         let mut f = File::open(path).expect("no file found");
+        #[allow(deprecated)]
         let (_, b) = wav::read(&mut f).unwrap();
+        #[allow(deprecated)]
         b.try_into_sixteen().unwrap()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@ pub use encode::encode;
 use std::io::{Read, Seek, SeekFrom};
 pub fn is_ogg_opus<T: Read + Seek>(mut d: T) -> bool {
     let mut buff = [0u8; 8];
-    if let Ok(_) = d.seek(SeekFrom::Start(28)) {
+    if d.seek(SeekFrom::Start(28)).is_ok() {
         if let Ok(d) = d.read(&mut buff) {
             if d == 8 {
-                return buff == decode::OPUS_MAGIC_HEADER;
+                return buff == common::OPUS_MAGIC_HEADER;
             }
         }
     }
@@ -32,7 +32,7 @@ pub enum Error {
     OggReadError(#[from] ogg::OggReadError),
 
     #[error("Failed to write in OGG")]
-    OggWriteError(#[from]std::io::Error),
+    OggWriteError(#[from] std::io::Error),
 
     #[error("Invalid samples per second")]
     InvalidSps,
@@ -40,71 +40,71 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{File};
-    use std::io::{Cursor};
+    use std::fs::File;
+    use std::io::Cursor;
 
-        fn read_file_i16(path: &str) -> Vec<i16> {
-            let mut f = File::open(path).expect("no file found");
-            let (_, b) = wav::read(&mut f).unwrap();
-            b.try_into_sixteen().unwrap()
-        }
+    fn read_file_i16(path: &str) -> Vec<i16> {
+        let mut f = File::open(path).expect("no file found");
+        let (_, b) = wav::read(&mut f).unwrap();
+        b.try_into_sixteen().unwrap()
+    }
 
-        #[test]
-        fn dec_enc_empty() {
-            let audio = Vec::new();
-            let opus = crate::encode::<16000, 1>(&audio).unwrap();
-            let enc_fin_range = crate::encode::get_final_range();
-            let (audio2, _) = crate::decode::<_,16000>(Cursor::new(opus)).unwrap();
-            let dec_fin_range = crate::decode::get_final_range();
-            assert_eq!(audio.len(), audio2.len()); // Should be the same, empty
-            assert_eq!(enc_fin_range, dec_fin_range);
-        }
+    #[test]
+    fn dec_enc_empty() {
+        let audio = Vec::new();
+        let opus = crate::encode::<16000, 1>(&audio).unwrap();
+        let enc_fin_range = crate::encode::get_final_range();
+        let (audio2, _) = crate::decode::<_, 16000>(Cursor::new(opus)).unwrap();
+        let dec_fin_range = crate::decode::get_final_range();
+        assert_eq!(audio.len(), audio2.len()); // Should be the same, empty
+        assert_eq!(enc_fin_range, dec_fin_range);
+    }
 
-        #[test]
-        fn dec_enc_recording_big() {
-            let audio = read_file_i16("test_assets/big.wav");
-            let opus = crate::encode::<16000, 1>(&audio).unwrap();
-            let enc_fin_range = crate::encode::get_final_range();
-            let (a2,_) = crate::decode::<_,16000>(Cursor::new(opus)).unwrap();
-            let dec_fin_range = crate::decode::get_final_range();
-            assert_eq!(dec_fin_range, enc_fin_range);
-            assert_eq!(audio.len(), a2.len());
-        }
+    #[test]
+    fn dec_enc_recording_big() {
+        let audio = read_file_i16("test_assets/big.wav");
+        let opus = crate::encode::<16000, 1>(&audio).unwrap();
+        let enc_fin_range = crate::encode::get_final_range();
+        let (a2, _) = crate::decode::<_, 16000>(Cursor::new(opus)).unwrap();
+        let dec_fin_range = crate::decode::get_final_range();
+        assert_eq!(dec_fin_range, enc_fin_range);
+        assert_eq!(audio.len(), a2.len());
+    }
 
-        #[test]
-        fn dec_enc_recording_small() {
-            // This file (when added the skip) decodes to exactly 63 20ms 
-            // + a 2.5 ms packet
-            let audio = read_file_i16("test_assets/small.wav");
-            let opus = crate::encode::<16000, 1>(&audio).unwrap();
-            let enc_fin_range = crate::encode::get_final_range();
-            let (a2, _) = crate::decode::<_, 16000>(Cursor::new(opus)).unwrap();
-            let dec_fin_range = crate::decode::get_final_range();
-            assert_eq!(dec_fin_range, enc_fin_range);
-            assert_eq!(audio.len(), a2.len());
-        }
+    #[test]
+    fn dec_enc_recording_small() {
+        // This file (when added the skip) decodes to exactly 63 20ms
+        // + a 2.5 ms packet
+        let audio = read_file_i16("test_assets/small.wav");
+        let opus = crate::encode::<16000, 1>(&audio).unwrap();
+        let enc_fin_range = crate::encode::get_final_range();
+        let (a2, _) = crate::decode::<_, 16000>(Cursor::new(opus)).unwrap();
+        let dec_fin_range = crate::decode::get_final_range();
+        assert_eq!(dec_fin_range, enc_fin_range);
+        assert_eq!(audio.len(), a2.len());
+    }
 
-        #[test]
-        // Record, encode, decode , encode and decode again, finally compare the
-        // first and second decodes, to make sure nothing is lost (can't compare
-        // raw audio as vorbis is lossy)
-        fn dec_enc_recording_whole() {
-            let audio = read_file_i16("test_assets/small.wav");
-            
-            let opus = crate::encode::<16000, 1>(&audio).unwrap();
-            let enc_fr1 = crate::encode::get_final_range();
+    #[test]
+    // Record, encode, decode , encode and decode again, finally compare the
+    // first and second decodes, to make sure nothing is lost (can't compare
+    // raw audio as vorbis is lossy)
+    fn dec_enc_recording_whole() {
+        let audio = read_file_i16("test_assets/small.wav");
 
-            let (audio2, _) = crate::decode::<_, 16000>(Cursor::new(opus)).unwrap();
-            let dec_fr1 = crate::decode::get_final_range();
+        let opus = crate::encode::<16000, 1>(&audio).unwrap();
+        let enc_fr1 = crate::encode::get_final_range();
 
-            let opus2 = crate::encode::<16000, 1>(&audio2).unwrap();
-            let enc_fr2 = crate::encode::get_final_range();
+        let (audio2, _) = crate::decode::<_, 16000>(Cursor::new(opus)).unwrap();
+        let dec_fr1 = crate::decode::get_final_range();
 
-            let (audio3, _) = crate::decode::<_, 16000>(Cursor::new(opus2)).unwrap();
-            let dec_fr2 = crate::decode::get_final_range();
+        let opus2 = crate::encode::<16000, 1>(&audio2).unwrap();
+        let enc_fr2 = crate::encode::get_final_range();
 
-            assert_eq!(audio2.len(), audio3.len());
-            assert_eq!(enc_fr1, dec_fr1);
-            assert_eq!(enc_fr2, dec_fr2);
-        }
+        let (audio3, _) = crate::decode::<_, 16000>(Cursor::new(opus2)).unwrap();
+        let dec_fr2 = crate::decode::get_final_range();
+
+        assert_eq!(audio2.len(), audio3.len());
+        assert_eq!(enc_fr1, dec_fr1);
+        assert_eq!(enc_fr2, dec_fr2);
+    }
 }


### PR DESCRIPTION
Hi!

I made these changes just for my (Telegram bot)[https://github.com/fr0staman/fr0staman_bot], I was just interested in improving performance.
Also, "inline const expressions" helped me with this, also added a compile time check.
Since I managed to improve the library a little, let it not go to waste.

List of changes:
- Add compile time errors on invalid const generics (sample rate, number of channels)
- Slightly faster on decode, less allocations
- Just a little bit faster on encode, very little less allocations
- Some refactoring
- Bump MSRV to 1.79